### PR TITLE
improvement: handle ubuntu installation methods

### DIFF
--- a/attributes/hardening.rb
+++ b/attributes/hardening.rb
@@ -19,13 +19,6 @@
 # limitations under the License.
 #
 
-case platform
-when 'debian', 'ubuntu'
-  default['nginx-hardening']['packages'] = 'nginx-extras'
-else
-  default['nginx-hardening']['packages'] = []
-end
-
 # security options
 
 default['nginx']['server_tokens'] = 'off'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,14 +19,27 @@
 # limitations under the License.
 #
 
-# Get required packages
-Array(node['nginx-hardening']['packages']).each do |p|
-  package p
+options = node['nginx-hardening']['options'].to_hash
+
+# OS-specific configuration
+if platform?('ubuntu', 'debian')
+
+  # when installing from canonical package on Ubuntu
+  # we can get additional modules via extra package
+  if node['nginx']['install_method'] == 'package'
+    package 'nginx-extras'
+
+  else
+    # repo and source installations have no extra modules
+    # on ubuntu/debian so the affected options must be removed
+    options.delete('more_clear_headers')
+  end
+
 end
 
 template "#{node['nginx']['dir']}/conf.d/90.hardening.conf" do
   source 'extras.conf.erb'
   variables(
-    options: NginxHardening.options(node['nginx-hardening']['options'])
+    options: NginxHardening.options(options)
   )
 end


### PR DESCRIPTION
On Ubuntu with package based installation, we currently get nginx v1.4 with the option to install nginx-extras and use some advanced configuration options (some of which we need for hardening).

When the user chooses to install from source or official nginx repo, this is not possible. For both cases, we won't use advanced options which are often not available. Installation from source has to be handled separately in the future with better customization.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
