### PR TITLE
more_clear_headers support in centos

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ if platform?('ubuntu', 'debian')
 
 end
 
-if platform_family?("rhel")
+if platform_family?('rhel')
   unless node['nginx']['repo_source'].nil?
     # repo and source installations have no extra modules
     # on ubuntu/debian so the affected options must be removed


### PR DESCRIPTION
If you are using the nginx repo under RHEL, more_clear_headers is not supported. This fix checks for the installation method and the operating system.
