### PR TITLE
Fix fedora more clear headers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,10 +21,6 @@ platforms:
 - name: ubuntu-14.04
   driver:
     image: ubuntu:14.04
-- name: ubuntu-15.10
-  driver:
-    image: ubuntu:15.10
-    pid_one_command: /bin/systemd
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,6 @@ gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '>= 12.0'
 gem 'inspec',     '~> 0'
 
-# pin dependency for Ruby 1.9.3 since bundler is not
-# detecting that net-ssh 3 does not work with 1.9.3
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
-  gem 'net-ssh', '~> 2.9'
-end
-
 group :test do
   gem 'rake'
   gem 'chefspec',   '~> 4.2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ maintainer_email "dominik.richter@googlemail.com"
 license          "Apache 2.0"
 description      "Configures nginx hardening"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.0"
 
 depends 'nginx', '>= 2.0.0'
 depends 'openssl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ maintainer_email "dominik.richter@googlemail.com"
 license          "Apache 2.0"
 description      "Configures nginx hardening"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.0.1"
 
 depends 'nginx', '>= 2.0.0'
 depends 'openssl'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,10 +39,10 @@ if platform?('ubuntu', 'debian')
 
 end
 
-if platform_family?('rhel')
+if platform_family?('rhel', 'fedora')
   unless node['nginx']['repo_source'].nil?
     # repo and source installations have no extra modules
-    # on ubuntu/debian so the affected options must be removed
+    # on RHEL/CentOS/Fedora so the affected options must be removed
     options.delete('more_clear_headers')
   end
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -19,7 +19,10 @@ require_relative '../spec_helper'
 
 describe 'nginx-hardening::default' do
 
-  let(:chef_run) { ChefSpec::SoloRunner.converge('nginx::default', described_recipe) }
+  before { allow_any_instance_of(Chef::Recipe).to receive(:search) }
+  let(:runner) { ChefSpec::ServerRunner.new }
+  let(:node) { runner.node }
+  let(:chef_run) { runner.converge('nginx::default', described_recipe) }
 
   before do
     stub_command('/usr/sbin/apache2 -t')


### PR DESCRIPTION
Using chef-nginx-hardening on Fedora 24 fails to remove the more_clear_headers directives correctly since Fedora is in it's own platform_family per https://github.com/chef/ohai/blob/master/lib/ohai/plugins/linux/platform.rb#L191-L194. This PR addresses this issue.