### PR TITLE
move to chef_nginx fork

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ source 'https://supermarket.getchef.com'
 
 metadata
 
-cookbook 'nginx', '>= 2.0.0'
+cookbook 'chef_nginx', '~> 3.1.1'
 cookbook 'chef-solo-search', git: 'https://github.com/edelight/chef-solo-search'

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ source 'https://supermarket.getchef.com'
 
 metadata
 
-cookbook 'chef_nginx', '~> 3.1.1'
+cookbook 'chef_nginx', '~> 3.1'
 cookbook 'chef-solo-search', git: 'https://github.com/edelight/chef-solo-search'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_attribute 'nginx'
+include_attribute 'chef_nginx'
 
 # to be on par with the puppet module defaults
 default['nginx']['repo_source'] = 'nginx'

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,7 +23,7 @@ description      "Configures nginx hardening"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.0"
 
-depends 'nginx', '>= 2.0.0'
+depends 'chef_nginx'
 depends 'openssl'
 
 recipe 'nginx-hardening::default', 'configures nginx for hardening'

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -22,7 +22,6 @@ describe 'nginx-hardening::default' do
   before { allow_any_instance_of(Chef::Recipe).to receive(:search) }
   let(:runner) { ChefSpec::ServerRunner.new }
   let(:node) { runner.node }
-  let(:chef_run) { runner.converge('nginx::default', described_recipe) }
 
   before do
     stub_command('/usr/sbin/apache2 -t')


### PR DESCRIPTION
Chef has forked the `nginx` cookbook at v`2.7`. Let's move to it.

https://supermarket.chef.io/cookbooks/chef_nginx
