### PR TITLE
update gem dependencies and fix lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-stable-trusty
     packages:
-      - chefdk
+      - chefdk=2.5.3-1
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
@@ -31,7 +31,7 @@ before_script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/embedded/bin/chef gem install coveralls -v 0.8.19 # needed for chefspecs
+  - /opt/chefdk/embedded/bin/chef gem install coveralls
 
 script: KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/embedded/bin/chef gem install coveralls
 
 script: KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,16 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 6.1'
-gem 'chef', '~> 12.5' # chefspec builds get stucked with 13.1
+gem 'berkshelf', '~> 6.3'
+gem 'chef', '~> 12'
 
 group :test do
   gem 'rake'
-  gem 'chefspec', '~> 7.1.0'
-  gem 'foodcritic', '~> 11.1'
-  gem 'thor', '~> 0.19.1'
-  gem 'thor-foodcritic'
-  gem 'cookstyle'
+  gem 'chefspec', '~> 7.2.1'
+  gem 'foodcritic', '~> 13.1'
+  gem 'cookstyle', '~> 3'
   gem 'coveralls', require: false
   gem 'minitest', '~> 5.10.2'
-  gem 'rubocop', '~> 0.49.0'
   gem 'simplecov', '~> 0.10'
 end
 

--- a/libraries/nginx_options.rb
+++ b/libraries/nginx_options.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-#
+
 # Cookbook Name:: nginx-hardening
 # Library:: nginx_options
 #
@@ -17,12 +17,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 class Chef
   class Recipe
     class NginxHardening
-      #
       def self.options(map, indentation = 0)
         # prep
         indent = '  ' * indentation
@@ -54,7 +52,6 @@ class Chef
             end
           end.join(indent)
       end
-      #
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-#
+
 # Copyright 2014, Dominik Richter
 # Copyright 2014, Deutsche Telekom AG
 #
@@ -18,14 +18,9 @@
 
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'coveralls'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
 end
-
-# coverage report
-Coveralls.wear!
-at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
This PR updates:
- lint
- dependencies
- removes coveralls (its not compatible with the latest chefdk)

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>